### PR TITLE
only turns on parallax for non-touch screen devices

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,8 @@
-var rellax = new Rellax('.parallax', {
-  center: true
-});
+const isCoarse =
+  typeof matchMedia !== undefined && matchMedia('(pointer:coarse)').matches
+
+if (!isCoarse) {
+  var rellax = new Rellax('.parallax', {
+    center: true
+  })
+}


### PR DESCRIPTION
It might be good to check on some devices like a chromebook to make sure you get the desired effect, because a chromebook might pass the isCoarse test.